### PR TITLE
Adding tests backs to prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:ci": "eslint .",
     "lint": "eslint .",
     "prepack": "yarn build",
-    "prepublishOnly": "yarn lint:ci",
+    "prepublishOnly": "yarn lint:ci && yarn test",
     "test": "jest",
     "watch": "tsc --watch"
   },


### PR DESCRIPTION
Adding tests back to prepublish script since this repo has already been published.
To explain better why all this was needed was because as this is a monorepo some examples packages called the main repo, create-lichtblick-extension via npm, but for that to work we would need to publish first the package, otherwise the tests and all the pipelines would fail because whenever create-lichtblick-extension was to be installed it would fail.