### PR TITLE
Updating pipelines to run on ubuntu latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -26,7 +26,7 @@ jobs:
       - run: yarn lint:ci
 
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -48,8 +48,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
           - windows-2022
 
     name: e2e (${{ matrix.os }})


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

This PR updates the GitHub Actions workflows to use the ubuntu-latest runner image, in anticipation of the [deprecation of Ubuntu 20.04 in GitHub Actions environments.](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/) This migration ensures that our CI pipelines remain functional and compatible with the latest GitHub Actions runner images, avoiding any potential issues as Ubuntu 20.04 reaches its end of support.



