### PR TITLE
fix: stop panel-settings example from spamming identical config

### DIFF
--- a/examples/panel-settings/src/ExamplePanel.tsx
+++ b/examples/panel-settings/src/ExamplePanel.tsx
@@ -109,10 +109,13 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): ReactEle
     [context],
   );
 
-  // Update the settings editor every time our state or the list of available topics changes.
+  // Persist state to the layout whenever it changes.
   useEffect(() => {
     context.saveState(state);
+  }, [context, state]);
 
+  // Update the settings editor when our state or the list of available topics changes.
+  useEffect(() => {
     const topicOptions = (topics ?? []).map((topic) => ({ value: topic.name, label: topic.name }));
 
     // We set up our settings tree to mirror the shape of our panel state so we


### PR DESCRIPTION
## Problem

The panel-settings example logs `"Panel action resulted in identical config: [object Object]"` at message rate during playback (up to 60hz). Reported in #11.

## Root cause

`context.saveState(state)` was inside a `useEffect` that also depended on `topics`:

```ts
useEffect(() => {
  context.saveState(state);          // ← called when topics changes
  context.updatePanelSettingsEditor({...});
}, [context, actionHandler, state, topics]);  // ← topics changes every render frame
```

During playback, `onRender` fires up to 60hz and calls `setTopics(renderState.topics)`, which triggers this effect. Since `state` hasn't changed, `saveState` receives identical config each frame.

## Fix

Split into two effects:

1. **`saveState`** — depends on `[context, state]` only (runs when user changes settings)
2. **`updatePanelSettingsEditor`** — depends on `[context, actionHandler, state, topics]` (refreshes topic dropdown when topics list changes)

This matches the pattern used by Lichtblick's own panels:
- **MapPanel**: separate `useEffect(() => { context.saveState(config) }, [context, config])`
- **ThreeDeeRender**: uses `useDebouncedCallback` for `saveState` (100ms throttle)

## Verification

The example is not covered by unit tests (it's a standalone React component). Verified by code review against the framework's own panel implementations.

Fixes #11